### PR TITLE
Included <exception> std header

### DIFF
--- a/src/Hardware/ExceptionHandlers.cpp
+++ b/src/Hardware/ExceptionHandlers.cpp
@@ -11,6 +11,7 @@
 #include <Platform/Tasks.h>
 #include <Hardware/NonVolatileMemory.h>
 #include <Cache.h>
+#include <exception>
 #if SAME70 || SAM4S || SAM4E
 # include <Reset.h>
 #endif


### PR DESCRIPTION
The <exception> header is required to compile v3.3 on Debian Linux, or an error gets thrown on the call to 'std::terminate_handler', line 296 (now 297).  

Admittedly not necessary if the package is built on Gloomy's recommended stack. But the rest of the build runs rather smoothly on debian, and the <exception> header is quite small to include
